### PR TITLE
nightlies: attempt to build Linux binaries without Internet

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       # Bump this value when a rebuild of nightlies (of the
       # same compiler commits) has to be done.
-      nightlies_revision: 2
+      nightlies_revision: 3
 
     steps:
       - name: Checkout nightlies
@@ -389,7 +389,13 @@ jobs:
         if: steps.built.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          nightlies/build-release.sh 'nim-${{ steps.source.outputs.version }}'
+          if [[ '${{ runner.os }}' == Linux ]]; then
+            # Build nightlies without Internet to ensure that generated source
+            # can be built without Internet.
+            sudo unshare sudo -u "$USER" nightlies/build-release.sh 'nim-${{ steps.source.outputs.version }}'
+          else
+            nightlies/build-release.sh 'nim-${{ steps.source.outputs.version }}'
+          fi
 
       - name: Prepare binaries for uploads
         id: release


### PR DESCRIPTION
This allows us to test whether the source tarball is self-contained.